### PR TITLE
changes needed for adal auth

### DIFF
--- a/src/auth/progress.auth.js
+++ b/src/auth/progress.auth.js
@@ -88,6 +88,9 @@ limitations under the License.
         case progress.data.Session.AUTH_TYPE_FORM_SSO:
             authProv = new progress.data.AuthenticationProviderSSO(initObject.uri);
             break;
+            case progress.data.Session.AUTH_TYPE_ADAL:
+                authProv = new progress.data.AuthenticationProviderAdal(initObject.uri, initObject.authConfig);
+                break;
         default:
             // AuthenticationProvider: The 'init-object' parameter passed to the 'constructor' function
             //                          has an invalid value for the 'authenticationModel' property.

--- a/src/progress.session.js
+++ b/src/progress.session.js
@@ -3815,7 +3815,8 @@ limitations under the License.
                 // running the constructor
                 _pdsession._authProvider = new progress.data.AuthenticationProvider({
                     uri: this.serviceURI,
-                    authenticationModel: this.authenticationModel
+                    authenticationModel: this.authenticationModel,
+                    authConfig: this.authenticationModel === "adal" ? username : undefined
                 });
             }
             

--- a/src/progress.session.js
+++ b/src/progress.session.js
@@ -932,6 +932,7 @@ limitations under the License.
                             case progress.data.Session.AUTH_TYPE_BASIC :
                             case progress.data.Session.AUTH_TYPE_ANON :
                             case progress.data.Session.AUTH_TYPE_SSO :
+                            case progress.data.Session.AUTH_TYPE_ADAL :
                             case null :
                                 _authenticationModel = newval;
                                 storeSessionInfo("authenticationModel", newval);
@@ -3411,7 +3412,10 @@ limitations under the License.
         Object.defineProperty(progress.data.Session, 'AUTH_TYPE_FORM_SSO', {
             value: "form_sso", enumerable: true
         });
-        
+        Object.defineProperty(progress.data.Session, 'AUTH_TYPE_ADAL', {
+            value: "adal", enumerable: true
+        });
+
 
         Object.defineProperty(progress.data.Session, 'DEVICE_OFFLINE', {
             value: "Device is offline", enumerable: true
@@ -3443,6 +3447,7 @@ limitations under the License.
         progress.data.Session.AUTH_TYPE_BASIC = "basic";
         progress.data.Session.AUTH_TYPE_FORM = "form";
         progress.data.Session.AUTH_TYPE_SSO = "sso";
+        progress.data.Session.AUTH_TYPE_ADAL = "adal";
 
         /* deliberately not including the "offline reasons" that are defined in the
          * 1st part of the conditional. We believe that we can be used only in environments where
@@ -4501,6 +4506,10 @@ limitations under the License.
                 authProviderInitObject.authenticationModel = options.authenticationModel;
             }
 
+            if (options.authConfig) {
+                authProviderInitObject.authConfig = options.authConfig;
+            }
+
             authProvider = new progress.data.AuthenticationProvider(authProviderInitObject);
             options.authProvider = authProvider;
             
@@ -4508,7 +4517,7 @@ limitations under the License.
                 loginHandler(authProvider);
             } else {
                 // If model is anon, just log in.
-                if (authProvider.authenticationModel === progress.data.Session.AUTH_TYPE_ANON) {
+                if (authProvider.authenticationModel === progress.data.Session.AUTH_TYPE_ANON || authProvider.authenticationModel === progress.data.Session.AUTH_TYPE_ADAL) {
                     authProvider.login()
                         .then(loginHandler, sessionRejectHandler);
                 } else {


### PR DESCRIPTION
Hi, 

I implemented authentication to Azure AD with JSDO.  I make use of adal.js  provided by Microsoft.

The changes in the PR are needed to allow loading the new authlib.
The actual implementation of the progress.auth.adal can be found in https://github.com/RobinHerbots/jsdo.adal.git  
You can pick the lib and integrate within jsdo if wanted.

Remark:
I chose to create a separate repo as I wanted to import the dependency to adal.js. 

For additional auth providers there is always the need to adapt the progress.auth.js and progress.session.js files.  Better would be to implement some kind of registration of auth providers, so no extra changes are needed.