### PR TITLE
Fixed the calls to callback functions in openRequestAndAuthorize

### DIFF
--- a/src/auth/progress.auth.basic.js
+++ b/src/auth/progress.auth.basic.js
@@ -118,12 +118,12 @@ limitations under the License.
                 }
 
                 progress.data.Session._setNoCacheHeaders(xhr);
+                callback(xhr);
             } else {
                 // AuthenticationProvider: The AuthenticationProvider is not managing valid credentials.
                 errorObject = new Error(progress.data._getMsgText("jsdoMSG125", "AuthenticationProvider"));
+                callback(errorObject);
             }
-
-            callback(errorObject);
         };
     };
 

--- a/src/auth/progress.auth.form.js
+++ b/src/auth/progress.auth.form.js
@@ -188,8 +188,12 @@ limitations under the License.
         function (xhr, verb, uri, async, callback) {
 
             function afterSuper(errorObject) {
-                xhr.withCredentials = true;
-                callback(errorObject);
+                if (errorObject instanceof Error) {
+                    callback(errorObject);
+                } else {
+                    xhr.withCredentials = true;
+                    callback(xhr);
+                }
             }
             
             try {

--- a/src/auth/progress.auth.js
+++ b/src/auth/progress.auth.js
@@ -251,12 +251,12 @@ limitations under the License.
 
             // Check out why we do this in _loginProto
             xhr.setRequestHeader("Accept", "application/json");
+            callback(xhr);
         } else {
             // AuthenticationProvider: The AuthenticationProvider is not managing valid credentials.
             errorObject = new Error(progress.data._getMsgText("jsdoMSG125", "AuthenticationProvider"));
+            callback(errorObject);
         }
-        
-        callback(errorObject);
     };
 
     // GENERAL PURPOSE "INTERNAL" METHODS, NOT RELATED TO SPECIFIC API ELEMENTS

--- a/src/auth/progress.auth.sso.js
+++ b/src/auth/progress.auth.sso.js
@@ -285,10 +285,12 @@ limitations under the License.
                     progress.data.AuthenticationProviderSSO.prototype._openRequestAndAuthorize.apply(
                         that,
                         [xhr, verb, uri, async, function (errorObject) {
-                            if (!errorObject) {
+                            if (errorObject instanceof Error) {
+                                callback(errorObject);
+                            } else {
                                 xhr.setRequestHeader('Authorization', "oecp " + getToken());
+                                callback(xhr);
                             }
-                            callback(errorObject);
                         }]
                     );
                 }

--- a/src/progress.session.js
+++ b/src/progress.session.js
@@ -1449,28 +1449,34 @@ limitations under the License.
             var urlPlusCCID,
                 that = this;
 
-            function afterOpenAndAuthorize(xhr) {
-                // add CCID header
-                if (that.clientContextId && (that.clientContextId !== "0")) {
-                    xhr.setRequestHeader("X-CLIENT-CONTEXT-ID", that.clientContextId);
-                }
-                // set X-CLIENT-PROPS header
-                setRequestHeaderFromContextProps(that, xhr);
-
-                if (typeof that.onOpenRequest === 'function') {
-                    var params = {
-                        "xhr": xhr,
-                        "verb": verb,
-                        "uri": urlPlusCCID,
-                        "async": async,
-                        "formPreTest": false,
-                        "session": that
-                    };
-                    that.onOpenRequest(params);
-                    // xhr = params.xhr; //Note that, currently, this would have no effect in the caller.
-                }
-                if (callback) {
-                    callback();
+            function afterOpenAndAuthorize(arg) {
+                // _openRequestAndAuthorize can return either an Error or an xhr
+                // TODO: we might need to fix this 
+                if (arg instanceof Error) {
+                    throw arg;
+                } else {
+                    // add CCID header
+                    if (that.clientContextId && (that.clientContextId !== "0")) {
+                        xhr.setRequestHeader("X-CLIENT-CONTEXT-ID", that.clientContextId);
+                    }
+                    // set X-CLIENT-PROPS header
+                    setRequestHeaderFromContextProps(that, xhr);
+    
+                    if (typeof that.onOpenRequest === 'function') {
+                        var params = {
+                            "xhr": xhr,
+                            "verb": verb,
+                            "uri": urlPlusCCID,
+                            "async": async,
+                            "formPreTest": false,
+                            "session": that
+                        };
+                        that.onOpenRequest(params);
+                        // xhr = params.xhr; //Note that, currently, this would have no effect in the caller.
+                    }
+                    if (callback) {
+                        callback();
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] See our contributing guidelines: https://github.com/progress/JSDO/blob/master/contributing.md#contribute-to-the-code-base.
- [x] You have signed the [CLA](https://www.progress.com/jsdo/cla).

[Describe the impact of the changes here. Please include issue # if applicable.]
AP._openRequestAndAuthorize() incorrectly ALWAYS calls the callback function given to it with an errorObject. The correct behavior is that it calls the callback with the xhr as its argument if everything is good and with an actual Error object if something goes wrong. 

You can tell this is the desired behavior since the default AP creates an Error object if something is wrong. If we were meant to always return the XHR, then we wouldn't've created the Error object. Alternatively, maybe we throw the error instead. However, I think this is the right way to do this.

I've fixed the logic in all of the AP models to do this. 

Misc information: 

3 functions call afterOpenRequestAndAuthorize() 

1. afterOpenAndAuthorize()
  * This function expects an xhr to be passed in the callback and what was causing the bug.
2. addCatalogAfterOpen()
  * This doesn't care what it gets
3. sendPingAfterOpen()
  * * This doesn't care what it gets
<!--
Thank you for your contribution!
-->
