### PR TITLE
Removed base64 dependency

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -33,8 +33,7 @@
   },
   "homepage": "https://github.com/progress/JSDO#readme",
   "dependencies": {
-    "@progress/jsdo-core": "^6.0.0",
-    "base-64": "^0.1.0"
+    "@progress/jsdo-core": "^6.0.0"
   },
   "peerDependencies": {
     "@angular/core": "^6.1.0",

--- a/src/progress.util.js
+++ b/src/progress.util.js
@@ -46,7 +46,7 @@ limitations under the License.
     var pkg_xmlhttprequest              = "xmlhttprequest",
         pkg_nodeLocalstorage            = "node-localstorage",
         pkg_nativescriptLocalstorage    = "nativescript-localstorage",
-        pkg_fileSystemAccess            = "file-system/file-system-access"
+        pkg_fileSystemAccess            = "file-system/file-system-access",
         pkg_base64                      = "base-64"
         ;
 

--- a/src/progress.util.js
+++ b/src/progress.util.js
@@ -47,6 +47,7 @@ limitations under the License.
         pkg_nodeLocalstorage            = "node-localstorage",
         pkg_nativescriptLocalstorage    = "nativescript-localstorage",
         pkg_fileSystemAccess            = "file-system/file-system-access"
+        pkg_base64                      = "base-64"
         ;
 
     // If XMLHttpRequest is undefined, enviroment would appear to be Node.js
@@ -97,7 +98,7 @@ limitations under the License.
         // load module base-64
         try {
             if (typeof btoa === "undefined") {
-                btoa = require("base-64").encode;
+                btoa = require("" + pkg_base64).encode;
             }
         } catch(exception3) {
             console.error("Error: JSDO library requires btoa() function in NativeScript.\n"
@@ -127,7 +128,7 @@ limitations under the License.
         // load module base-64
         try {
             if (typeof btoa === "undefined") {
-                btoa = require("base-64").encode;
+                btoa = require("" + pkg_base64).encode;
             }
         } catch(exception3) {
             console.error("Error: JSDO library requires btoa() function in Node.js.\n"


### PR DESCRIPTION
Updated package.json of jsdo-angular to not have base-64 dependency.
Tested JSDO locally, no errors