### PR TITLE
Updated JSDOSession smoke tests to use private containers

### DIFF
--- a/test/smoke.jsdosession.js
+++ b/test/smoke.jsdosession.js
@@ -38,11 +38,11 @@ describe('JSDOSession Smoke Tests', () => {
 
         it('should connect to an existing basic backend', function () {
             let getSession = progress.data.getSession({
-                serviceURI: 'http://oemobiledemo.progress.com/OEMobileDemoServicesBasic/',
-                catalogURI: 'http://oemobiledemo.progress.com/OEMobileDemoServicesBasic/static/CustomerService.json',
+                serviceURI: 'http://172.29.18.125:8894/OEMobileDemoServicesBasic',
+                catalogURI: 'http://172.29.18.125:8894/OEMobileDemoServicesBasic/static/CustomerService.json',
                 authenticationModel: 'basic',
-                username: 'basicuser',
-                password: 'basicpassword'
+                username: 'restuser',
+                password: 'password'
             }).then((object) => {
                 object.jsdosession.invalidate();
                 return object.result; 


### PR DESCRIPTION
Updated the tests to point to our docker container instead of the public oemobiledemoservices