### PR TITLE
Adding eslinting to the core and tslinting to the angular project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .vscode
 package-lock.json
 tmp
-tslint.json
 node_modules/
 scratch1/
 scratch2/

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build:jsdo": "mkdirp build && concat -o build/progress.jsdo.js src/progress.util.js src/progress.js src/progress.session.js src/auth/progress.auth.js src/auth/progress.auth.basic.js src/auth/progress.auth.form.js src/auth/progress.auth.sso.js",
+    "lint": "eslint --quiet src/*",
     "test": "npm run build:jsdo && mocha --recursive",
     "test:smokes": "npm run build:jsdo && mocha test/smoke*.js",
     "test:tc-smokes": "npm run build:jsdo && mocha test/smoke*.js --recursive --reporter mocha-teamcity-reporter",
@@ -42,6 +43,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "concat": "^1.0.3",
+    "eslint": "^5.7.0",
     "mkdirp": "^0.5.1",
     "mocha": "^5.2.0",
     "mocha-teamcity-reporter": "^2.4.0",

--- a/packages/ng-datasource/package.json
+++ b/packages/ng-datasource/package.json
@@ -16,7 +16,8 @@
     "test": "npm run build:ds && mocha --recursive",
     "test:smokes": "npm run build:ds && mocha test/smoke*.js",
     "test:tc": "npm run build:ds && mocha --recursive --reporter mocha-teamcity-reporter",
-    "test:tc-smokes": "npm run build:ds && mocha test/smoke*.js --recursive --reporter mocha-teamcity-reporter"
+    "test:tc-smokes": "npm run build:ds && mocha test/smoke*.js --recursive --reporter mocha-teamcity-reporter",
+    "lint": "eslint src/*"
   },
   "repository": {
     "type": "git",

--- a/packages/ng-datasource/tslint.json
+++ b/packages/ng-datasource/tslint.json
@@ -1,0 +1,15 @@
+{
+    "defaultSeverity": "error",
+    "extends": [
+        "tslint:recommended"
+    ],
+    "jsRules": {},
+    "rules": {
+        "interface-name": [true, "never-prefix"],
+        "member-access": [true, "no-public"],
+        "no-string-literal": false,
+        "object-literal-shorthand": [false],
+        "variable-name": [true, "allow-leading-underscore"]
+    },
+    "rulesDirectory": []
+}

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -15,7 +15,8 @@
     "test": "npm run build:ds && mocha --recursive",
     "test:smokes": "npm run build:ds && mocha test/smoke*.js",
     "test:tc": "npm run build:ds && mocha --recursive --reporter mocha-teamcity-reporter",
-    "test:tc-smokes": "npm run build:ds && mocha test/smoke*.js --recursive --reporter mocha-teamcity-reporter"
+    "test:tc-smokes": "npm run build:ds && mocha test/smoke*.js --recursive --reporter mocha-teamcity-reporter",
+    "lint": "tslint --project ."
   },
   "repository": {
     "type": "git",
@@ -37,7 +38,7 @@
   },
   "homepage": "https://github.com/progress/JSDO#readme",
   "dependencies": {
-    "@progress/jsdo-core": "^6.0.1",
+    "@progress/jsdo-core": "^6.0.0",
     "base-64": "^0.1.0",
     "node-localstorage": "^1.3.1",
     "xmlhttprequest": "^1.8.0",
@@ -51,6 +52,8 @@
     "concat": "^1.0.3",
     "mkdirp": "^0.5.1",
     "mocha": "^5.2.0",
-    "mocha-teamcity-reporter": "^2.4.0"
+    "mocha-teamcity-reporter": "^2.4.0",
+    "tslint": "^5.11.0",
+    "typescript": "^3.1.3"
   }
 }


### PR DESCRIPTION
So I noticed how other packages have some sort of linting commands in their package.json so I figure ours should do the same.

Since our source code is in jsdo-core as well as ng-datasource, I just added the linting commands there since there's no real point in linting the other packages since it's a literal carbon copy of whatever's in ng-datasource.

My plan is to just run:

npm install
npm run lint

In a TeamCity command so we see the output. And then potentially save it to a file too.