### PR TITLE
Updated encoding of an Authorization header for BASIC authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "peerDependencies": {},
   "optionalDependencies": {},
   "devDependencies": {
-    "base-64": "^0.1.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "concat": "^1.0.3",

--- a/src/progress.util.js
+++ b/src/progress.util.js
@@ -36,15 +36,13 @@ limitations under the License.
     // - xmlhttprequest
     // NativeScript:
     // - nativescript-localstorage
-    // - base-64
 
     var isNativeScript = false,
         isNodeJS = false;
 
     var pkg_xmlhttprequest              = "xmlhttprequest",
         pkg_nativescriptLocalstorage    = "nativescript-localstorage",
-        pkg_fileSystemAccess            = "file-system/file-system-access",
-        pkg_base64                      = "base-64"
+        pkg_fileSystemAccess            = "file-system/file-system-access"
         ;
 
     //In memory localStorage emulation used for node 
@@ -101,14 +99,13 @@ limitations under the License.
                 + "Please install nativescript-localstorage package.");
         }
 
-        // load module base-64
+        // Polyfill the btoa() function (which we use to encode BASIC authorization)
         try {
             if (typeof btoa === "undefined") {
-                btoa = require("" + pkg_base64).encode;
+                btoa = function(str) { return Buffer.from(str).toString('base64'); }
             }
         } catch(exception3) {
-            console.error("Error: JSDO library requires btoa() function in NativeScript.\n"
-                + "Please install base-64 package.");
+            console.error("Error: JSDO library requires toString('base-64') function in NativeScript.");
         }
     }
 
@@ -121,14 +118,13 @@ limitations under the License.
             sessionStorage = new LocalStorageEmulation();
         }
 
-        // load module base-64
+        // Polyfill the btoa() function (which we use to encode BASIC authorization)
         try {
             if (typeof btoa === "undefined") {
-                btoa = require("" + pkg_base64).encode;
+                btoa = function(str) { return Buffer.from(str).toString('base64'); }
             }
         } catch(exception3) {
-            console.error("Error: JSDO library requires btoa() function in Node.js.\n"
-                + "Please install base-64 package.");
+            console.error("Error: JSDO library requires toString('base-64')function in Node.js.");
         }
     }
 }());

--- a/test/smoke.jsdo.js
+++ b/test/smoke.jsdo.js
@@ -9,8 +9,8 @@ chai.use(chaiAsPromised);
 describe('JSDO Smoke Tests', () => {
     // INFORMATION YEAH
     const options = {    
-        catalogURI: "http://172.29.18.125:8894/OEMobileDemoServices/static/CustomerService.json",
-        serviceURI: "http://172.29.18.125:8894/OEMobileDemoServices/",
+        catalogURI: "https://oemobiledemo.progress.com/OEMobileDemoServices/static/CustomerService.json",
+        serviceURI: "https://oemobiledemo.progress.com/OEMobileDemoServices/",
         resourceName: "Customer",
         authenticationModel: "anonymous"
     };

--- a/test/smoke.jsdosession.js
+++ b/test/smoke.jsdosession.js
@@ -9,8 +9,8 @@ chai.use(chaiAsPromised);
 describe('JSDOSession Smoke Tests', () => {
     // INFORMATION YEAH
     const options = {    
-        catalogURI: 'http://172.29.18.125:8894/OEMobileDemoServices/static/CustomerService.json',
-        serviceURI: 'http://172.29.18.125:8894/OEMobileDemoServices/',
+        catalogURI: 'https://oemobiledemo.progress.com/OEMobileDemoServices/static/CustomerService.json',
+        serviceURI: 'https://oemobiledemo.progress.com/OEMobileDemoServices/',
         authenticationModel: 'anonymous'
     };
 
@@ -38,11 +38,11 @@ describe('JSDOSession Smoke Tests', () => {
 
         it('should connect to an existing basic backend', function () {
             let getSession = progress.data.getSession({
-                serviceURI: 'http://172.29.18.125:8894/OEMobileDemoServicesBasic',
-                catalogURI: 'http://172.29.18.125:8894/OEMobileDemoServicesBasic/static/CustomerService.json',
+                serviceURI: 'https://oemobiledemo.progress.com/OEMobileDemoServicesBasic',
+                catalogURI: 'https://oemobiledemo.progress.com/OEMobileDemoServicesBasic/static/CustomerService.json',
                 authenticationModel: 'basic',
-                username: 'restuser',
-                password: 'password'
+                username: 'basicuser',
+                password: 'basicpassword'
             }).then((object) => {
                 object.jsdosession.invalidate();
                 return object.result; 


### PR DESCRIPTION
So the way we encoded was with the base-64 package's encode(). This function did not properly encode special characters (pretty much non-ASCII stuff was bonked).

With node's August 2018 update, there is now an in-house way to encode stuff. We don't need the base-64 package now, which is good.

`// from https://gist.github.com/brandonmwest/a2632d0a65088a20c00a`
`auth = (Buffer.from(`${username}:${password}`).toString('base64')`

So I removed the base-64 dependency and just used the build in Node toString('base-64') functionality instead. 