### PR TITLE
Added Unicode encoding specifically for the browser

### DIFF
--- a/packages/nativescript/notice.txt
+++ b/packages/nativescript/notice.txt
@@ -23,26 +23,7 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-(b) Progress Data Source for NativeScript incorporates base-64 v0.1.0.  Such technology is subject to the following terms and conditions:
-Copyright Mathias Bynens <http://mathiasbynens.be/>
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-(c) Progress Data Source for NativeScript incorporates nativescript-localstorage v2.0.0.  Such technology is subject to the following terms and conditions:
+(b) Progress Data Source for NativeScript incorporates nativescript-localstorage v2.0.0.  Such technology is subject to the following terms and conditions:
 The MIT License (MIT)
 localstorage
 Copyright (c) 2016, Nathanael Anderson

--- a/packages/nativescript/package.json
+++ b/packages/nativescript/package.json
@@ -36,7 +36,6 @@
   "homepage": "https://github.com/progress/JSDO#readme",
   "dependencies": {
     "@progress/jsdo-core": "^6.0.1",
-    "base-64": "^0.1.0",
     "nativescript-localstorage": "^1.1.5",
     "zone.js": "^0.8.18"
   },

--- a/src/progress.util.js
+++ b/src/progress.util.js
@@ -105,7 +105,7 @@ limitations under the License.
                 btoa = function(str) { return Buffer.from(str).toString('base64'); }
             }
         } catch(exception3) {
-            console.error("Error: JSDO library requires toString('base-64') function in NativeScript.");
+            console.error("Error: JSDO library requires toString('base64') function in NativeScript.");
         }
     }
 
@@ -124,7 +124,22 @@ limitations under the License.
                 btoa = function(str) { return Buffer.from(str).toString('base64'); }
             }
         } catch(exception3) {
-            console.error("Error: JSDO library requires toString('base-64')function in Node.js.");
+            console.error("Error: JSDO library requires toString('base64')function in Node.js.");
+        }
+    }
+
+    // If we're running in the browser, edit btoa() to properly encode Unicode strings
+    // taken from https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa#Unicode_strings
+    if (!isNodeJS && !isNativeScript) {
+        if (typeof btoa !== "undefined") {
+            let btoaOriginal = btoa;
+
+            // this section of code is functionally identical to the toString('base-64')
+            // btoa() doesn't exist on node though, which is why we have different styles
+            // of encoding in NS/node
+            btoa = function (str) {
+                return btoaOriginal(unescape(encodeURIComponent(str)));
+            };
         }
     }
 }());


### PR DESCRIPTION
In the previous PR, I added proper encoding (and removed the base-64 pkg) for BASIC Authorization headers so that special characters (like é could be handled correctly). This change was for node/nativescript environments.

Browsers could potentially have different behaviour. I deemed that it'd be okay not to solve it (since most people use the JSDO as a npm package and not really run it on the browser anymore) but I added a fix to make sure browsers also properly encode Unicode strings. 