### PR TITLE
Sso open request and authorize bug

### DIFF
--- a/src/auth/progress.auth.sso.js
+++ b/src/auth/progress.auth.sso.js
@@ -305,13 +305,13 @@ limitations under the License.
                     this.hasRefreshToken() &&    
                     date.getTime() > retrieveAccessTokenExpiration()) {
                     try {
-                        var callback = function (params, result, info) {
+                        var callback_Refresh = function (params, result, info) {
                             params = progress.util.Deferred.getParamObject(params, result, info);
                             afterRefreshCheck(params.provider, params.result, params.info);
                         };
                         // finally
                         this.refresh()
-                            .then(callback, callback);
+                            .then(callback_Refresh, callback_Refresh);
                     } catch (e) {
                         callback(e);
                     }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x ] Read our contributing guidelines: https://github.com/progress/JSDO/blob/master/contributing.md#contribute-to-the-code-base.

Using AUTH_TYPE_SSO authentication model I found that upon expiration of the access token It would get caught in a loop inside the _openRequestAndAuthorize function. I found this issue to be the result of a variable name "callback" declared on 308 which is already in use by the _openRequestAndAuthorize function. I renamed the variable "callback" at 308 to "callbackRefresh" and updated 314 as well in order to reference the correct variable.  After finding and fixing this issue I then found that this also relates to issue #265 .
This has been tested and functioning in our project. 

<!--
Thank you for your contribution!
-->
