### PR TITLE
fix: accept @angular v6 and later as peer

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -36,7 +36,7 @@
     "@progress/jsdo-core": "^6.0.1"
   },
   "peerDependencies": {
-    "@angular/core": "^6.1.0",
+    "@angular/core": ">= 6",
     "rxjs": "^6.0.0"
   },
   "optionalDependencies": {}


### PR DESCRIPTION
## PR Checklist

- [x] Read our contributing guidelines: https://github.com/progress/JSDO/blob/master/contributing.md#contribute-to-the-code-base.

The library doesn't seem to have issues with v9 at least although I haven't tested with v10 just yet.

As an alternative, the version range can be restricted, e.g. to `6-10`.

